### PR TITLE
Adding TelemetryCorrelationHttpModule into web.config when user enable AI.

### DIFF
--- a/AppInsightsProvider/Web.install.config
+++ b/AppInsightsProvider/Web.install.config
@@ -2,6 +2,8 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.webServer>
     <modules>
+      <add xdt:Transform="Remove" xdt:Locator="Condition(@name='TelemetryCorrelationHttpModule')" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" xdt:Transform="Insert" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='ApplicationInsightsWebTracking')" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" xdt:Transform="Insert" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='DnnAppInsights')" />

--- a/AppInsightsProvider/Web.uninstall.config
+++ b/AppInsightsProvider/Web.uninstall.config
@@ -2,6 +2,7 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.webServer>
     <modules>
+      <add xdt:Transform="Remove" xdt:Locator="Condition(@name='TelemetryCorrelationHttpModule')" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='ApplicationInsightsWebTracking')" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='DnnAppInsights')" />
     </modules>


### PR DESCRIPTION
Adding TelemetryCorrelationHttpModule into web.config when user enable AI.
After install I found that Request Tracking not working because we missing this config.